### PR TITLE
Add Headings + refactor Text

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -1,0 +1,48 @@
+import Text from './Text'
+
+const Heading = Text.withComponent('h3')
+
+Heading.displayName = 'Heading'
+
+Heading.defaultProps = {
+  fontSize: 4,
+  m: 0
+}
+
+Heading.h1 = Heading.withComponent('h1')
+Heading.h1.defaultProps = {
+  fontSize: 6,
+  m: 0
+}
+
+Heading.h2 = Heading.withComponent('h2')
+Heading.h2.defaultProps = {
+  fontSize: 5,
+  m: 0
+}
+
+Heading.h3 = Heading.withComponent('h3')
+Heading.h3.defaultProps = {
+  fontSize: 4,
+  m: 0
+}
+
+Heading.h4 = Heading.withComponent('h4')
+Heading.h4.defaultProps = {
+  fontSize: 3,
+  m: 0
+}
+
+Heading.h5 = Heading.withComponent('h5')
+Heading.h5.defaultProps = {
+  fontSize: 2,
+  m: 0
+}
+
+Heading.h6 = Heading.withComponent('h6')
+Heading.h6.defaultProps = {
+  fontSize: 1,
+  m: 0
+}
+
+export default Heading

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -1,11 +1,25 @@
-import styled, { withTheme } from 'styled-components'
-import hoc from '../hoc'
-import { font } from '../theme'
-import { compose } from 'recompose'
+import styled from 'styled-components'
+import { fontSize, space, color, responsiveStyle } from 'styled-system'
 
-const Base = styled.p`
-  font-family: ${font};
-  font-size: inherit;
-`
+export const caps = props =>
+  props.caps
+    ? {
+      textTransform: 'uppercase',
+      letterSpacing: '0.2em'
+    }
+    : null
 
-export default compose(withTheme, hoc)(Base)
+export const bold = props =>
+  props.bold
+    ? { fontWeight: props.theme.weights[props.theme.weights.length - 1] }
+    : null
+
+const align = responsiveStyle('text-align', 'align')
+
+const Text = styled.div`${fontSize} ${space} ${color} ${caps} ${bold} ${align};`
+
+Text.displayName = 'Text'
+Text.span = Text.withComponent('span')
+Text.p = Text.withComponent('p')
+
+export default Text

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import { default as Select } from './components/Select'
 import { default as Text } from './components/Text'
 import { default as Textarea } from './components/Textarea'
 import { default as Image } from './components/Image'
+import { default as Heading } from './components/Heading'
 
 import { Flex, Box } from './components/Grid'
 
@@ -30,6 +31,7 @@ export {
   Filters,
   Fixed,
   Flex,
+  Heading,
   Input,
   Image,
   Modal,

--- a/src/stories/Typography.js
+++ b/src/stories/Typography.js
@@ -1,0 +1,35 @@
+import { h } from 'preact'
+import { storiesOf } from '@storybook/react'
+import styled from 'styled-components'
+import Text from '../components/Text'
+import Heading from '../components/Heading'
+
+const Container = styled.div`margin: 60px;`
+
+storiesOf('Typography', module)
+  .addDecorator(story => <Container>{story()}</Container>)
+  .addWithInfo('Headings', () => {
+    return (
+      <div>
+        <Heading.h1>Heading h1</Heading.h1>
+        <Heading.h2>Heading h2</Heading.h2>
+        <Heading.h3>Heading h3</Heading.h3>
+        <Heading.h4>Heading h4</Heading.h4>
+        <Heading.h5>Heading h5</Heading.h5>
+        <Heading.h6>Heading h6</Heading.h6>
+      </div>
+    )
+  })
+  .addWithInfo('Text', props => {
+    return (
+      <div>
+        <Text>Standard text</Text>
+        <Text align='center'>Centered</Text>
+        <Text align='right'>Right</Text>
+        <Text bold>Bold</Text>
+        <Text.span color='blue'>Inline </Text.span>
+        <Text.span color='red'>Inline </Text.span>
+        <Text.span color='yellow'>Inline </Text.span>
+      </div>
+    )
+  })


### PR DESCRIPTION
Connects to #97

Change-type: minor

Shamelessly borrowed from https://github.com/pricelinelabs/design-system. I've realized that the HoC is actually not a great pattern for styled components, for reasons I mentioned in the button refactor PR. I think we should instead pull in utilities from styled-system on a per component basis, it seems to be making things simpler. 